### PR TITLE
Add Cloud Agent development environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,6 +1,6 @@
 {
   "name": "atoma",
-  "install": "npm ci",
+  "install": "npm ci && npm run build",
   "terminals": [
     {
       "name": "viz",

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,15 @@
+{
+  "name": "atoma",
+  "install": "npm ci",
+  "terminals": [
+    {
+      "name": "viz",
+      "command": "npm run viz:dev",
+      "description": "Atoma visualizer: API on 127.0.0.1:4111, Vite GPU UI on 127.0.0.1:5173."
+    }
+  ],
+  "ports": [
+    { "name": "viz api", "port": 4111 },
+    { "name": "viz ui", "port": 5173 }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a repository-managed Cloud Agent environment (`.cursor/environment.json`) so `atoma` is fully usable in Cloud Agents out of the box.

The repo previously had no `.cursor/environment.json` and no linked environment. This adds one using Cursor's default base image, which already ships the Node 22 toolchain `better-sqlite3` needs — no Dockerfile required.

## Config

- `install`: `npm ci && npm run build` — installs pinned deps from the lockfile, then builds `dist/` so the **compiled** entrypoints work on fresh pods (`doctor`, `mcp`, `auth`, `projects`, `sentinel`, `viz:serve`, `run:build`). A first draft build used `npm ci` alone; a fresh Cloud Agent showed the compiled `npm run doctor` failing with `Cannot find module .../dist/cli/doctor.js`, so the build step was added.
- `terminals`: launches the Atoma visualizer (`npm run viz:dev`) — API on `127.0.0.1:4111`, Vite GPU UI on `127.0.0.1:5173`. Runs from source (tsx) with hot reload.
- `ports`: exposes `4111` (viz API) and `5173` (viz UI).

## Validation (on this VM, against a clean `npm ci`)

- `npm run check` — docs check + typecheck (`tsconfig.json` and `tsconfig.all.json`) + eslint + **2723 tests passed** (8 skipped).
- `npm run build` — `tsc` + viz GPU bundle built; re-runs are idempotent.
- `npm run doctor` (compiled) — `READY WITH WARNINGS` (only the expected `ANTHROPIC_API_KEY` / Docker-optional warnings).
- `node scripts/release-smoke.mjs` — `13 MCP tools, 4 prompts, JSON-only stdout, compiled viz UI/API`.
- `node scripts/auth-release-smoke.mjs` — full auth flow (login, invite, admission, PKCE, session gate, logout).
- Visualizer (`viz:serve` / `viz:dev`) served HTTP 200 on `/api/runs`, `/api/registries`, `/api/profiles`; UI renders and navigates in Chrome (splash → dashboard → Docs).

## Clean-pod build verification

- Draft build with `install: npm ci && npm run build` **SUCCEEDED**: 482 packages, 0 vulnerabilities, `tsc` + viz bundle built, snapshot ready.
- A fresh Cloud Agent on this branch confirmed: `node v22.14.0` / `npm 10.9.7`, `npm ci` clean, `better-sqlite3` native addon loads, `viz:dev` terminal serves (`4111`→307→`5173`→200, `/api/profiles` OK), and `npm run typecheck` passes.

## Notes

`ANTHROPIC_API_KEY` is only needed to execute live LLM runs — not for the environment, tests, or the visualizer. Add it as a secret to enable live runs. Docker is optional (only for `--container` isolated runs / `build:worker`).

Because this config is committed to the repository, it is the highest-precedence environment source and applies automatically to future Cloud Agents once merged — no dashboard save required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b1fa863-abe7-48b6-a404-44b4c05b83eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b1fa863-abe7-48b6-a404-44b4c05b83eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

