### PR TITLE
fix(supervisor): make mender containers support runtime checks

### DIFF
--- a/docker/mender.Dockerfile
+++ b/docker/mender.Dockerfile
@@ -1,5 +1,10 @@
 FROM node:22.14.0-bookworm
-RUN apt-get update && apt-get install -y --no-install-recommends git python3 make g++ \
+RUN apt-get update && apt-get install -y --no-install-recommends git python3 make g++ chromium ca-certificates procps \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g @anthropic-ai/claude-code
 WORKDIR /work
+
+# Every command gets a fresh container. Keep the browser in the image, as the
+# tool worker does, rather than downloading it into a disposable /tmp cache.
+ENV PUPPETEER_SKIP_DOWNLOAD=1 \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium

--- a/src/supervisor/AGENTS.md
+++ b/src/supervisor/AGENTS.md
@@ -75,6 +75,10 @@ Neighbours:
   no additional swap, one CPU, 512 MiB tmpfs, one Vitest worker. Host Codex is
   text-only and holds a dedicated ChatGPT profile; the harness alone holds the
   GitHub publisher token. Never give containers product state or credentials.
+- Chromium and its libraries live in the mender image, with Puppeteer downloads
+  disabled. Each fresh command can run browser tests without an install cache.
+  Synthetic read-only passwd/group files describe only the executing UID/GID;
+  Node gets a 1536 MiB heap within the existing 2 GiB container limit.
 - `deploy/install-mender.sh` installs from a verified deployed revision, preserves
   an existing clone and configuration, and removes retired dispatch settings.
   The developer CLI remains available with the same idle reservation.

--- a/src/supervisor/menderIsolation.ts
+++ b/src/supervisor/menderIsolation.ts
@@ -38,17 +38,29 @@ export const runIsolatedMenderCommand: typeof runCommand = async (spec, extraArg
     writeFileSync(gitFile, 'gitdir: /atoma-git\n');
     const env = menderContainerEnv(options.env ?? {});
     const command = resolveCommand(spec);
+    // Numeric --user preserves worktree ownership, but does not create a passwd
+    // entry. Supply container-only identity data so homedir() also works when
+    // a child unsets HOME. Never mount the host's account database.
+    const uid = process.getuid!();
+    const gid = process.getgid!();
+    const passwd = join(metadataRoot, 'passwd');
+    const group = join(metadataRoot, 'group');
+    writeFileSync(passwd, `mender:x:${uid}:${gid}:Mender:/tmp:/usr/sbin/nologin\n`, { mode: 0o644 });
+    writeFileSync(group, `mender:x:${gid}:\n`, { mode: 0o644 });
     const args = [
       'run', '--name', name, '--label', 'atoma.role=mender', '--rm', '--init',
       ...(options.input !== undefined || options.onLine ? ['--interactive'] : []),
       '--cap-drop=ALL', '--security-opt=no-new-privileges', '--read-only',
       '--pids-limit=512', '--memory=2g', '--memory-swap=2g', '--cpus=1',
-      '--user', `${process.getuid!()}:${process.getgid!()}`,
+      '--user', `${uid}:${gid}`,
       '--tmpfs', '/tmp:rw,nosuid,nodev,exec,size=512m',
       '--mount', `type=bind,src=${options.cwd},dst=/work`,
       '--mount', `type=bind,src=${metadata},dst=/atoma-git,readonly`,
+      '--mount', `type=bind,src=${passwd},dst=/etc/passwd,readonly`,
+      '--mount', `type=bind,src=${group},dst=/etc/group,readonly`,
       '--workdir', '/work', '--env', 'HOME=/tmp', '--env', 'HUSKY=0',
       '--env', 'VITEST_MAX_WORKERS=1',
+      '--env', 'NODE_OPTIONS=--max-old-space-size=1536',
       ...(options.network ? ['--network', options.network] : []),
       ...Object.keys(env).flatMap((key) => ['--env', key]),
       process.env['ATOMA_MENDER_SANDBOX_IMAGE'] ?? 'atoma-mender:local',

--- a/tests/mender-isolation.test.ts
+++ b/tests/mender-isolation.test.ts
@@ -16,6 +16,24 @@ it('passes inference credentials only, without publisher tokens or host config',
 });
 
 describe.skipIf(process.env['ATOMA_MENDER_CONTAINER_TESTS'] !== '1')('mender container boundary', () => {
+  it('installs then runs the production browser and HOME regressions in a fresh offline container', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'atoma-mender-runtime-'));
+    roots.push(root);
+    const repo = join(root, 'repo');
+    const work = join(root, 'work');
+    execFileSync('git', ['clone', '--no-local', process.cwd(), repo], { stdio: 'pipe' });
+    execFileSync('git', ['-C', repo, 'worktree', 'add', '--detach', work, 'HEAD'], { stdio: 'pipe' });
+    const install = await runIsolatedMenderCommand('npm ci', [], { cwd: work, timeoutMs: 300_000 });
+    expect(install.code, install.stdout + install.stderr).toBe(0);
+    const checked = await runIsolatedMenderCommand('npx vitest run', [
+      'tests/smoke-message-legibility.test.ts',
+      'tests/validate-html-bounds.test.ts',
+      'tests/puppeteer-orphan-reaping.test.ts',
+      'tests/backup.test.ts',
+    ], { cwd: work, timeoutMs: 180_000, network: 'none' });
+    expect(checked.code, checked.stdout + checked.stderr).toBe(0);
+  }, 600_000);
+
   it('executes proposed code without publisher credentials, host files or host processes', async () => {
     const root = mkdtempSync(join(tmpdir(), 'atoma-mender-isolation-'));
     roots.push(root);
@@ -49,6 +67,29 @@ describe.skipIf(process.env['ATOMA_MENDER_CONTAINER_TESTS'] !== '1')('mender con
     expect(result.code, result.stderr).toBe(0);
     expect(readFileSync(join(work, 'result.txt'), 'utf8')).toBe('isolated');
     expect(readFileSync(join(work, '.git'), 'utf8')).toBe(original);
+    // Installation and verification are separate disposable containers. Both
+    // must find a browser without downloading one, even with networking off.
+    writeFileSync(join(work, 'browser.html'), '<html><body>mender-browser-proof</body></html>');
+    for (let phase = 0; phase < 2; phase++) {
+      const runtime = await runIsolatedMenderCommand('node', ['-e', `
+        const assert = require('node:assert/strict');
+        const os = require('node:os');
+        const cp = require('node:child_process');
+        delete process.env.HOME;
+        assert.equal(os.homedir(), '/tmp');
+        assert.equal(os.userInfo().uid, process.getuid());
+        assert.equal(os.userInfo().gid, process.getgid());
+        assert.ok(require('node:v8').getHeapStatistics().heap_size_limit > 1500 * 1024 * 1024);
+        assert.equal(process.env.PUPPETEER_SKIP_DOWNLOAD, '1');
+        const html = cp.execFileSync(process.env.PUPPETEER_EXECUTABLE_PATH, [
+          '--headless', '--no-sandbox', '--disable-dev-shm-usage',
+          '--dump-dom', 'file:///work/browser.html',
+        ], { encoding: 'utf8', timeout: 30000 });
+        assert.ok(html.includes('mender-browser-proof'));
+      `], { cwd: work, timeoutMs: 60_000, network: 'none' });
+      expect(runtime.code, runtime.stderr).toBe(0);
+      expect(readFileSync(join(work, '.git'), 'utf8')).toBe(original);
+    }
     const auth = join(root, 'auth'); mkdirSync(auth);
     writeFileSync(join(auth, 'auth.json'), JSON.stringify({ auth_mode: 'chatgpt', tokens: { refresh_token: 'credential-sentinel' } }));
     const command = `
@@ -82,5 +123,5 @@ describe.skipIf(process.env['ATOMA_MENDER_CONTAINER_TESTS'] !== '1')('mender con
     await new Promise((resolveWait) => setTimeout(resolveWait, 3_100));
     expect(() => readFileSync(join(work, 'late-write'))).toThrow();
     expect(readFileSync(join(work, '.git'), 'utf8')).toBe(original);
-  }, 90_000);
+  }, 180_000);
 });

--- a/tests/puppeteer-orphan-reaping.test.ts
+++ b/tests/puppeteer-orphan-reaping.test.ts
@@ -93,7 +93,7 @@ import { ToolSandbox } from '${repo}/src/tools/sandbox.ts';
 import { validateHtmlTool } from '${repo}/src/tools/builtin.ts';
 const sandbox = new ToolSandbox(${JSON.stringify(dir)});
 await validateHtmlTool({ sandbox }).execute({ url: 'about:blank', waitMs: 10 }).catch(() => {});
-console.log('READY');
+console.log('READY:' + JSON.stringify([...sandbox.trackedChildPids()]));
 setInterval(() => {}, 1000);   // idle like a delivered run that started a server
 `,
       'utf8'
@@ -104,8 +104,8 @@ setInterval(() => {}, 1000);   // idle like a delivered run that started a serve
       detached: true, // exactly how burnin.ts spawns a run
       stdio: ['ignore', 'pipe', 'pipe'],
     });
-    // The puppeteer processes THIS child owns, found by walking the live
-    // process tree from its pid. Not a machine-wide pgrep: under a fully
+    // The browser processes THIS child owns, found by walking the live
+    // process tree from its tracked browser PIDs. Not a machine-wide pgrep: under a fully
     // parallel suite the other browser-driving test files inflate and
     // deflate a global count between any two samples (measured 2026-08-31:
     // "leaked" came out at -6 because six unrelated Chromes had exited
@@ -113,14 +113,14 @@ setInterval(() => {}, 1000);   // idle like a delivered run that started a serve
     // launches Chrome detached into a group of its own, so the reap this
     // test proves travels through the child's exit handler, not through
     // group membership.
-    const puppeteerDescendants = (): number[] => {
+    const puppeteerDescendants = (browserRoots: number[]): number[] => {
       const rows = execSync('ps -eo pid=,ppid=,args=', { encoding: 'utf8' })
         .trim()
         .split('\n')
         .map((row) => /^\s*(\d+)\s+(\d+)\s+(.*)$/.exec(row))
         .filter((m): m is RegExpExecArray => m !== null)
         .map((m) => ({ pid: Number(m[1]), ppid: Number(m[2]), args: m[3] ?? '' }));
-      const owned = new Set([child.pid!]);
+      const owned = new Set(browserRoots);
       let grew = true;
       while (grew) {
         grew = false;
@@ -132,7 +132,7 @@ setInterval(() => {}, 1000);   // idle like a delivered run that started a serve
         }
       }
       return rows
-        .filter((row) => owned.has(row.pid) && row.args.includes('.cache/puppeteer'))
+        .filter((row) => owned.has(row.pid))
         .map((row) => row.pid);
     };
     const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
@@ -141,7 +141,11 @@ setInterval(() => {}, 1000);   // idle like a delivered run that started a serve
     const upBy = Date.now() + 90_000;
     while (!/READY/.test(out) && Date.now() < upBy) await sleep(200);
     expect(/READY/.test(out), `child never booted a browser. out=${out}`).toBe(true);
-    const browserPids = puppeteerDescendants();
+    const reported = /READY:(\[.*\])/.exec(out);
+    expect(reported, `child did not report browser PIDs: ${out}`).toBeTruthy();
+    const browserRoots = JSON.parse(reported![1]!) as number[];
+    expect(browserRoots.length).toBeGreaterThan(0);
+    const browserPids = puppeteerDescendants(browserRoots);
     expect(browserPids.length).toBeGreaterThan(0); // the browser really is up
 
     process.kill(-child.pid!, 'SIGTERM'); // the harness's first signal


### PR DESCRIPTION
Mender verification failed on the VPS because each command discarded Puppeteer's downloaded browser, the numeric container UID had no passwd entry when a backup test unset HOME, and TypeScript exhausted Node's default heap.

Install system Chromium in the mender image, using the worker's existing Puppeteer configuration. Mount synthetic read-only account files for the executing UID/GID and give Node a 1536 MiB heap within the unchanged 2 GiB container limit. Publisher credentials remain outside the container.

Regression coverage installs a clean worktree in one container and runs the four production failure suites in another offline container. Additional checks launch Chromium twice and resolve the home directory with HOME unset. The orphan-reaping test now follows tracked browser PIDs and their descendants instead of assuming a Puppeteer download path.

Validation: local release:check passed (3,459 tests, zero audit vulnerabilities); CI release:check passed on Node 22 and Node 24; all three real Docker boundary tests passed, including the nested production regression suites. The revised orphan-reaping test also passed locally with the downloaded browser.
